### PR TITLE
Fixed the SPA url and a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Handling browser navigation implemented in F# and targeting Fable.
-========
+# Handling browser navigation implemented in F# and targeting Fable.
 
 This is a navigation sample ported from Elm.
 In addition to `init`, `update`, `view` functions it introduces `hashParser` and `urlUpdate` to handle browser navigation events.
@@ -7,11 +6,8 @@ In addition to `init`, `update`, `view` functions it introduces `hashParser` and
 For more information about it see [the docs](https://fable-elmish.github.io/browser).
 
 ## Building and running the sample
-Pre-built SPA is avaialble on https://fable-elmish.github.io/sample-react-navigation.
+
+Pre-built SPA is available at https://elmish.github.io/sample-react-navigation.
 To build locally and start the webpack-devserver on http://localhost:8080 :
 
 `build Watch`
-
-
-
-


### PR DESCRIPTION
Changed the url to the new one (without "fable" at the start of the url), and fixed a couple of typos